### PR TITLE
Fix for Yoast crashing caused by WordPress custom theme function

### DIFF
--- a/content/themes/wcmc-europe/functions.php
+++ b/content/themes/wcmc-europe/functions.php
@@ -296,7 +296,7 @@ add_action(
 			if (use_block_editor_for_post_type($post_type)) {
 				register_rest_field(
 					$post_type,
-					'blocks',
+					'gutenberg_blocks',
 					[
 						'get_callback' => function (array $post) {
 							return parse_blocks($post['content']['raw']);


### PR DESCRIPTION
Changing 'blocks' to 'gutenberg_blocks' in surfacing rest api function, as blocks is a reserved word